### PR TITLE
Cloud watch filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ custom:
     layerArn: arn:aws:lambda:us-east-1:451483290750:layer:NewRelicPython37:2
 ```
 
+#### `cloudWatchFilter` (optional)
+
+Provide a list of quoted filter terms for the CloudWatch log subscription to the newrelic-log-ingestion Lambda. Combines all terms into an OR filter. Defaults to "NR_LAMBDA_MONITORING" if not set. Use "*" to capture all logs
+
+```yaml
+custom:
+  newRelic:
+    cloudWatchFilter:
+    - "NR_LAMBDA_MONITORING"
+    - "trace this"
+    - "ERROR"
+```
+
 #### `prepend` (optional)
 
 Whether or not to prepend the IOpipe layer. Defaults to `false` which appends the layer.

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,14 +77,12 @@ export default class NewRelicLambdaLayerPlugin {
     const funcs = this.functions;
     let { cloudWatchFilter = [ "NR_LAMBDA_MONITORING" ] } = this.config;
     
-    if(cloudWatchFilter.length == 1 && cloudWatchFilter[0] == "*") {
-        delete cloudWatchFilter[0];
-    }
-    else if(cloudWatchFilter.length > 1) {
+    let cloudWatchFilterString = ""
+    if(!cloudWatchFilter.find( filter => filter == "*")) {
         cloudWatchFilter = cloudWatchFilter.map(el => `?\"${el}\"`);
+        cloudWatchFilterString = cloudWatchFilter.join(" ");
     }
-      
-    const cloudWatchFilterString = cloudWatchFilter.join(" ");
+    
     this.serverless.cli.log(`log filter: ${cloudWatchFilterString}`);
     
     Object.keys(funcs).forEach(async funcName => {


### PR DESCRIPTION
Add optional configuration to specify a custom filter for the CloudWatch log subscription.
Configuration defaults to the standard "NR_LAMBDA_MONITORING" filter.
If the filter is configured as "*" it will capture all logs.
If multiple filters are provided they are combined into an OR filter.
