### PR TITLE
Adding fallback type checking on cloudWatchFilter input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,10 @@ export default class NewRelicLambdaLayerPlugin {
     let { cloudWatchFilter = ["NR_LAMBDA_MONITORING"] } = this.config;
 
     let cloudWatchFilterString = "";
-    if (typeof cloudWatchFilter === "object" && cloudWatchFilter.indexOf("*") === -1) {
+    if (
+      typeof cloudWatchFilter === "object" &&
+      cloudWatchFilter.indexOf("*") === -1
+    ) {
       cloudWatchFilter = cloudWatchFilter.map(el => `?\"${el}\"`);
       cloudWatchFilterString = cloudWatchFilter.join(" ");
     } else if (cloudWatchFilter.indexOf("*") === -1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,9 +78,11 @@ export default class NewRelicLambdaLayerPlugin {
     let { cloudWatchFilter = ["NR_LAMBDA_MONITORING"] } = this.config;
 
     let cloudWatchFilterString = "";
-    if (!cloudWatchFilter.find(filter => filter === "*")) {
+    if (typeof cloudWatchFilter === "object" && cloudWatchFilter.indexOf("*") === -1) {
       cloudWatchFilter = cloudWatchFilter.map(el => `?\"${el}\"`);
       cloudWatchFilterString = cloudWatchFilter.join(" ");
+    } else if (cloudWatchFilter.indexOf("*") === -1) {
+      cloudWatchFilterString = String(cloudWatchFilter);
     }
 
     this.serverless.cli.log(`log filter: ${cloudWatchFilterString}`);


### PR DESCRIPTION
Checks for non-array filter input, and uses the more-performant `.indexOf()` in place of `.find()`.

Closes #19