### PR TITLE
Version needs to be bumped before publishing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
NPM isn't happy with un-bumped package.json version