### PR TITLE
Forcing new version to keep package.json in sync with release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
OK, *this* release should stick. 