### PR TITLE
Replace forEach with for..of to allow promise to complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,10 +63,10 @@ export default class NewRelicLambdaLayerPlugin {
     }
 
     const funcs = this.functions;
-    Object.keys(funcs).forEach(async funcName => {
+    for (const funcName of Object.keys(funcs)) {
       const funcDef = funcs[funcName];
       await this.addLayer(funcName, funcDef);
-    });
+    }
   }
 
   public cleanup() {


### PR DESCRIPTION
After configuring `serverless-webpack` I've noticed that *NewRelic* configuration is not being generated. With a little bit debugging I found the problem with `for each` and replaced with `for .. of`. 

Placed the link that explain the problem below:
https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop

And output after adding console log:
*forEach*
<img width="590" alt="Screenshot 2019-12-11 at 21 47 27" src="https://user-images.githubusercontent.com/2106178/70664133-b908f980-1c61-11ea-9c1a-e58a78c30042.png">

*for..of*
<img width="657" alt="Screenshot 2019-12-11 at 21 46 44" src="https://user-images.githubusercontent.com/2106178/70664154-c0c89e00-1c61-11ea-87b4-3f2630a3ee0c.png">

I hope it helps. 