### PR TITLE
Fixing default filter pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import * as Serverless from "serverless";
 import * as util from "util";
 
 const DEFAULT_FILTER_PATTERN =
-  '?REPORT ?NR_LAMBDA_MONITORING ?"Task timed out"';
+  '?REPORT ?NR_LAMBDA_MONITORING ?\\"Task timed out\\"';
 
 export default class NewRelicLambdaLayerPlugin {
   public serverless: Serverless;


### PR DESCRIPTION
Changing default filter pattern to avoid errors on deployment, and to pass tslint.

Bumping version to 0.1.12