### PR TITLE
enable to include functions versus exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ Logging configuration is considered in the following order:
 3. custom newRelic `logLevel` property
 4. custom newRelic `debug` flag
 
+=======
+
+#### `include` (optional)
+
+An array of functions to include for wrapping. When set it will only include defined functions.
+
+```yaml
+custom:
+  newRelic:
+    include:
+      - include-only-func
+```
+
 #### `exclude` (optional)
 
 An array of functions to exclude from automatic wrapping.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.1.16",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-newrelic-lambda-layers",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Serverless plugin for NewRelic APM AWS Lambda layers.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,9 +126,8 @@ export default class NewRelicLambdaLayerPlugin {
     this.serverless.cli.log(`log filter: ${cloudWatchFilterString}`);
 
     for (const funcName of Object.keys(funcs)) {
-
       if (this.shouldSkip(funcName)) {
-        return
+        return;
       }
 
       this.serverless.cli.log(
@@ -203,7 +202,7 @@ export default class NewRelicLambdaLayerPlugin {
     }
 
     if (this.shouldSkip(funcName)) {
-      return
+      return;
     }
 
     const layerArn = this.config.layerArn
@@ -249,8 +248,8 @@ export default class NewRelicLambdaLayerPlugin {
     environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY = environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY
       ? environment.NEW_RELIC_TRUSTED_ACCOUNT_KEY
       : environment.NEW_RELIC_ACCOUNT_ID
-        ? environment.NEW_RELIC_ACCOUNT_ID
-        : this.config.trustedAccountKey;
+      ? environment.NEW_RELIC_ACCOUNT_ID
+      : this.config.trustedAccountKey;
 
     if (runtime.match("python")) {
       environment.NEW_RELIC_SERVERLESS_MODE_ENABLED = "true";
@@ -280,7 +279,7 @@ export default class NewRelicLambdaLayerPlugin {
       return true;
     }
 
-    return false
+    return false;
   }
 
   private logLevel(environment) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,9 +83,8 @@ export default class NewRelicLambdaLayerPlugin {
       return;
     }
 
-    const { exclude = [] } = this.config;
-    const { include } = this.config;
-    if (!_.isEmpty(exclude) && !_.isUndefined(include)) {
+    const { exclude = [], include = [] } = this.config;
+    if (!_.isEmpty(exclude) && !_.isEmpty(include)) {
       this.serverless.cli.log(
         "exclude and include options are mutually exclusive; skipping."
       );
@@ -203,10 +202,9 @@ export default class NewRelicLambdaLayerPlugin {
       return;
     }
 
-    // const { exclude = [] } = this.config;
-    const { include } = this.config;
+    const { include = [] } = this.config;
     if (
-      !_.isUndefined(include) &&
+      !_.isEmpty(include) &&
       _.isArray(include) &&
       include.indexOf(funcName) === -1
     ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,18 @@ export default class NewRelicLambdaLayerPlugin {
     this.serverless.cli.log(`log filter: ${cloudWatchFilterString}`);
 
     for (const funcName of Object.keys(funcs)) {
+      const { include = [] } = this.config;
+      if (
+        !_.isEmpty(include) &&
+        _.isArray(include) &&
+        include.indexOf(funcName) === -1
+      ) {
+        this.serverless.cli.log(
+          `Excluded function ${funcName}; is not part of include skipping`
+        );
+        return;
+      }
+
       const { exclude = [] } = this.config;
       if (_.isArray(exclude) && exclude.indexOf(funcName) !== -1) {
         return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ export default class NewRelicLambdaLayerPlugin {
         include.indexOf(funcName) === -1
       ) {
         this.serverless.cli.log(
-          `Excluded function ${funcName}; is not part of include skipping`
+          `Function ${funcName} is not included for instrumentation; skipping.`
         );
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,15 @@ export default class NewRelicLambdaLayerPlugin {
       return;
     }
 
+    const { exclude = [] } = this.config;
+    const { include } = this.config;
+    if (!_.isEmpty(exclude) && !_.isUndefined(include)) {
+      this.serverless.cli.log(
+        "exclude and include options are mutually exclusive; skipping."
+      );
+      return;
+    }
+
     const funcs = this.functions;
     for (const funcName of Object.keys(funcs)) {
       const funcDef = funcs[funcName];
@@ -190,6 +199,19 @@ export default class NewRelicLambdaLayerPlugin {
     ) {
       this.serverless.cli.log(
         `Unsupported runtime "${runtime}" for NewRelic layer; skipping.`
+      );
+      return;
+    }
+
+    // const { exclude = [] } = this.config;
+    const { include } = this.config;
+    if (
+      !_.isUndefined(include) &&
+      _.isArray(include) &&
+      include.indexOf(funcName) === -1
+    ) {
+      this.serverless.cli.log(
+        `Excluded function ${funcName}; is not part of include skipping`
       );
       return;
     }

--- a/tests/fixtures/include-exclude.input.service.json
+++ b/tests/fixtures/include-exclude.input.service.json
@@ -1,0 +1,46 @@
+{
+  "service": "newrelic-lambda-layers-nodejs-example",
+  "provider": {
+    "name": "aws",
+    "stage": "prod",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "plugins": ["serverless-newrelic-lambda-layers"],
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "include": ["layer-nodejs810"],
+      "exclude": ["layer-nodejs12x"]
+    }
+  },
+  "functions": {
+    "layer-nodejs810": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs8.10"
+    },
+    "layer-nodejs10x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs10.x"
+    },
+    "layer-nodejs12x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs12.x"
+    }
+  }
+}

--- a/tests/fixtures/include-exclude.output.service.json
+++ b/tests/fixtures/include-exclude.output.service.json
@@ -1,0 +1,46 @@
+{
+  "service": "newrelic-lambda-layers-nodejs-example",
+  "provider": {
+    "name": "aws",
+    "stage": "prod",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "plugins": ["serverless-newrelic-lambda-layers"],
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "include": ["layer-nodejs810"],
+      "exclude": ["layer-nodejs12x"]
+    }
+  },
+  "functions": {
+    "layer-nodejs810": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs8.10"
+    },
+    "layer-nodejs10x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs10.x"
+    },
+    "layer-nodejs12x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs12.x"
+    }
+  }
+}

--- a/tests/fixtures/include.input.service.json
+++ b/tests/fixtures/include.input.service.json
@@ -1,0 +1,45 @@
+{
+  "service": "newrelic-lambda-layers-nodejs-example",
+  "provider": {
+    "name": "aws",
+    "stage": "prod",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "plugins": ["serverless-newrelic-lambda-layers"],
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "include": ["layer-nodejs810"]
+    }
+  },
+  "functions": {
+    "layer-nodejs810": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs8.10"
+    },
+    "layer-nodejs10x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs10.x"
+    },
+    "layer-nodejs12x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs12.x"
+    }
+  }
+}

--- a/tests/fixtures/include.output.service.json
+++ b/tests/fixtures/include.output.service.json
@@ -1,0 +1,58 @@
+{
+  "service": "newrelic-lambda-layers-nodejs-example",
+  "provider": {
+    "name": "aws",
+    "stage": "prod",
+    "region": "us-east-1",
+    "stackTags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    },
+    "tags": {
+      "environment": "us-testing",
+      "owning_team": "LAMBDA",
+      "product": "aws-lambda"
+    }
+  },
+  "plugins": ["serverless-newrelic-lambda-layers"],
+  "custom": {
+    "newRelic": {
+      "accountId": "${env:NEW_RELIC_ACCOUNT_ID}",
+      "include": ["layer-nodejs810"]
+    }
+  },
+  "functions": {
+    "layer-nodejs810": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "newrelic-wrapper-helper.handler",
+      "layers": [
+        "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS810:8"
+      ],
+      "package": {
+        "exclude": ["./**", "!newrelic-wrapper-helper.js"],
+        "include": ["handler.js"]
+      },
+      "runtime": "nodejs8.10",
+      "environment": {
+        "NEW_RELIC_ACCOUNT_ID": "${env:NEW_RELIC_ACCOUNT_ID}",
+        "NEW_RELIC_APP_NAME": "layer-nodejs810",
+        "NEW_RELIC_LAMBDA_HANDLER": "handler.handler",
+        "NEW_RELIC_NO_CONFIG_FILE": "true",
+        "NEW_RELIC_TRUSTED_ACCOUNT_KEY": "${env:NEW_RELIC_ACCOUNT_ID}"
+      }
+    },
+    "layer-nodejs10x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs10.x"
+    },
+    "layer-nodejs12x": {
+      "events": [{ "schedule": "rate(5 minutes)" }],
+      "handler": "handler.handler",
+      "package": { "exclude": ["./**"], "include": ["handler.js"] },
+      "runtime": "nodejs12.x"
+    }
+  }
+}


### PR DESCRIPTION
In some cases, we found an exclude option a little bit awkward especially when you have only a single function to apply Layer on. 

I've added an include option which works as exclude but instead includes functions.